### PR TITLE
Move game source to string type (#3)

### DIFF
--- a/src/main/resources/api/types/game.raml
+++ b/src/main/resources/api/types/game.raml
@@ -31,12 +31,7 @@ properties:
     examples:
       Ex1: 500
   source:
-    enum: 
-      - tournament
-      - league
-      - arena
-      - challenge
-      - custom
+    type: string
     displayName: Source
     required: true
     description: |


### PR DESCRIPTION
Have seen receiving undocumented `source` type of `ladder`. Relaxing the type definition to avoid failures.